### PR TITLE
feat: add MD3 styled OSM map

### DIFF
--- a/gmaps-md3.html
+++ b/gmaps-md3.html
@@ -1,0 +1,211 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>MD3 OSM Google Maps MVP</title>
+  <!-- MapLibre GL CSS -->
+  <link href="https://unpkg.com/maplibre-gl@2.4.0/dist/maplibre-gl.css" rel="stylesheet" />
+  <!-- Material Icons font for map markers -->
+  <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet" />
+  <style>
+    html, body, #root {
+      height: 100%;
+      margin: 0;
+    }
+    #map {
+      position: absolute;
+      top: 104px; /* app bar + buttons approx */
+      bottom: 56px; /* bottom nav */
+      width: 100%;
+    }
+    .quick-actions {
+      position: absolute;
+      top: 56px;
+      left: 0;
+      right: 0;
+      display: flex;
+      overflow-x: auto;
+      padding: 8px;
+      gap: 8px;
+      background: rgba(18,18,18,0.7);
+    }
+    .floating-buttons {
+      position: absolute;
+      bottom: 80px;
+      right: 16px;
+      display: flex;
+      flex-direction: column;
+      gap: 12px;
+    }
+  </style>
+</head>
+<body>
+  <div id="root"></div>
+  <div id="map"></div>
+  <!-- React and MUI -->
+  <script type="module">
+    import React, { useState, useEffect } from 'https://esm.sh/react@18';
+    import ReactDOM from 'https://esm.sh/react-dom@18/client';
+    import maplibregl from 'https://esm.sh/maplibre-gl@2.4.0';
+
+    import {
+      ThemeProvider,
+      createTheme,
+      CssBaseline,
+      AppBar,
+      Toolbar,
+      TextField,
+      InputAdornment,
+      IconButton,
+      Avatar,
+      Box,
+      Button,
+      Fab,
+      BottomNavigation,
+      BottomNavigationAction,
+      Paper
+    } from 'https://esm.sh/@mui/material@5.15.16';
+
+    import SearchIcon from 'https://esm.sh/@mui/icons-material/Search';
+    import MicIcon from 'https://esm.sh/@mui/icons-material/Mic';
+    import CameraAltIcon from 'https://esm.sh/@mui/icons-material/CameraAlt';
+    import HomeIcon from 'https://esm.sh/@mui/icons-material/Home';
+    import RestaurantIcon from 'https://esm.sh/@mui/icons-material/Restaurant';
+    import LocalCafeIcon from 'https://esm.sh/@mui/icons-material/LocalCafe';
+    import LocalGasStationIcon from 'https://esm.sh/@mui/icons-material/LocalGasStation';
+    import MoreHorizIcon from 'https://esm.sh/@mui/icons-material/MoreHoriz';
+    import ExploreIcon from 'https://esm.sh/@mui/icons-material/Explore';
+    import PersonPinIcon from 'https://esm.sh/@mui/icons-material/PersonPin';
+    import AddLocationAltIcon from 'https://esm.sh/@mui/icons-material/AddLocationAlt';
+    import LayersIcon from 'https://esm.sh/@mui/icons-material/Layers';
+    import NearMeIcon from 'https://esm.sh/@mui/icons-material/NearMe';
+
+    const theme = createTheme({
+      palette: {
+        mode: 'dark',
+      },
+    });
+
+    function QuickButtons() {
+      const buttons = [
+        { icon: HomeIcon, label: 'Home' },
+        { icon: RestaurantIcon, label: 'Restaurants' },
+        { icon: LocalCafeIcon, label: 'Coffee' },
+        { icon: LocalGasStationIcon, label: 'Gas' },
+        { icon: MoreHorizIcon, label: 'More' },
+      ];
+      return (
+        <Box className="quick-actions">
+          {buttons.map(({ icon: Icon, label }) => (
+            <Button key={label} variant="contained" startIcon={<Icon />}>{label}</Button>
+          ))}
+        </Box>
+      );
+    }
+
+    function MapComponent() {
+      useEffect(() => {
+        const map = new maplibregl.Map({
+          container: 'map',
+          style: 'https://basemaps.cartocdn.com/gl/dark-matter-gl-style/style.json',
+          center: [-118.2437,34.0522],
+          zoom: 12,
+        });
+
+        if (navigator.geolocation) {
+          navigator.geolocation.getCurrentPosition(pos => {
+            const { latitude, longitude } = pos.coords;
+            map.setCenter([longitude, latitude]);
+            new maplibregl.Marker({ color: '#8ab4f8' })
+              .setLngLat([longitude, latitude])
+              .addTo(map);
+          });
+        }
+
+        const pois = [
+          { lngLat: [-118.244, 34.053], icon: 'shopping_cart', title: 'Vons', rating: 4.2 },
+          { lngLat: [-118.247, 34.051], icon: 'content_cut', title: 'Great Clips', rating: 4.0 },
+          { lngLat: [-118.245, 34.055], icon: 'school', title: 'School', rating: 4.5 }
+        ];
+
+        pois.forEach(p => {
+          const el = document.createElement('div');
+          el.style.cssText = 'background:#1e88e5;border-radius:50%;padding:4px;color:white;';
+          el.innerHTML = `<span class="material-icons" style="font-size:20px;">${p.icon}</span>`;
+          new maplibregl.Marker({ element: el })
+            .setLngLat(p.lngLat)
+            .setPopup(new maplibregl.Popup().setHTML(`<strong>${p.title}</strong><br/>${p.rating}★`))
+            .addTo(map);
+        });
+      }, []);
+      return null;
+    }
+
+    function FloatingButtons() {
+      return (
+        <Box className="floating-buttons">
+          <Fab color="primary" size="small"><NearMeIcon /></Fab>
+          <Fab color="primary" size="small"><LayersIcon /></Fab>
+        </Box>
+      );
+    }
+
+    function BottomNav() {
+      const [value, setValue] = useState(0);
+      return (
+        <Paper sx={{ position: 'fixed', bottom: 0, left: 0, right: 0 }} elevation={3}>
+          <BottomNavigation value={value} onChange={(_, newValue) => setValue(newValue)} showLabels>
+            <BottomNavigationAction label="Explore" icon={<ExploreIcon />} />
+            <BottomNavigationAction label="You" icon={<PersonPinIcon />} />
+            <BottomNavigationAction label="Contribute" icon={<AddLocationAltIcon />} />
+          </BottomNavigation>
+        </Paper>
+      );
+    }
+
+    function App() {
+      return (
+        <ThemeProvider theme={theme}>
+          <CssBaseline />
+          <AppBar position="fixed" color="default">
+            <Toolbar>
+              <TextField
+                variant="filled"
+                fullWidth
+                placeholder="Search here"
+                InputProps={{
+                  startAdornment: (
+                    <InputAdornment position="start">
+                      <SearchIcon />
+                    </InputAdornment>
+                  ),
+                  endAdornment: (
+                    <>
+                      <InputAdornment position="end">
+                        <IconButton size="small"><MicIcon /></IconButton>
+                      </InputAdornment>
+                      <InputAdornment position="end">
+                        <IconButton size="small"><CameraAltIcon /></IconButton>
+                      </InputAdornment>
+                    </>
+                  ),
+                }}
+              />
+              <IconButton color="inherit">
+                <Avatar sx={{ width: 32, height: 32 }}>U</Avatar>
+              </IconButton>
+            </Toolbar>
+          </AppBar>
+          <QuickButtons />
+          <MapComponent />
+          <FloatingButtons />
+          <BottomNav />
+        </ThemeProvider>
+      );
+    }
+
+    ReactDOM.createRoot(document.getElementById('root')).render(<App />);
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add MD3 expressive map MVP with React, MapLibre, and Material UI
- include quick action buttons, floating controls, bottom navigation, and sample POI markers

## Testing
- `npm test` *(fails: missing package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689e55c75314833288e96e49b6993b7f