### PR TITLE
Redesign portfolio site

### DIFF
--- a/assets/css/style.scss
+++ b/assets/css/style.scss
@@ -1,0 +1,254 @@
+---
+---
+@import "{{ site.theme }}";
+
+:root {
+  --ink: #10231f;
+  --muted: #5f706b;
+  --surface: #ffffff;
+  --surface-soft: #f5f8f6;
+  --brand: #10a37f;
+  --brand-dark: #08745c;
+  --accent: #dff7ee;
+  --line: rgba(16, 35, 31, 0.12);
+  --shadow: 0 24px 70px rgba(16, 35, 31, 0.12);
+}
+
+body {
+  color: var(--ink);
+  background:
+    radial-gradient(circle at top left, rgba(16, 163, 127, 0.16), transparent 32rem),
+    linear-gradient(180deg, #f7fbf9 0%, #eef6f2 45%, #ffffff 100%);
+  font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+}
+
+.page-header {
+  display: none;
+}
+
+.main-content {
+  max-width: 1180px;
+  padding: 0 1.5rem 4rem;
+  font-size: 1.05rem;
+}
+
+.main-content h1,
+.main-content h2,
+.main-content h3 {
+  color: var(--ink);
+  font-weight: 800;
+}
+
+.main-content h2 {
+  margin-top: 0;
+  margin-bottom: 1rem;
+  border-bottom: 0;
+}
+
+.main-content a {
+  color: var(--brand-dark);
+}
+
+.site-nav {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 1rem;
+  padding: 1.25rem 0;
+}
+
+.brand-mark {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.7rem;
+  font-weight: 800;
+  color: var(--ink) !important;
+  text-decoration: none;
+}
+
+.logo-dot {
+  width: 2.5rem;
+  height: 2.5rem;
+  border-radius: 999px;
+  display: grid;
+  place-items: center;
+  background: var(--ink);
+  color: #fff;
+  box-shadow: 0 10px 30px rgba(16, 163, 127, 0.25);
+}
+
+.nav-links {
+  display: flex;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+}
+
+.nav-links a,
+.button,
+.secondary-button {
+  border-radius: 999px;
+  padding: 0.75rem 1.05rem;
+  text-decoration: none !important;
+  font-weight: 700;
+}
+
+.nav-links a,
+.secondary-button {
+  background: rgba(255,255,255,0.74);
+  border: 1px solid var(--line);
+  color: var(--ink) !important;
+}
+
+.button {
+  background: var(--brand);
+  color: #fff !important;
+  border: 1px solid var(--brand);
+  box-shadow: 0 14px 30px rgba(16, 163, 127, 0.25);
+}
+
+.hero {
+  display: grid;
+  grid-template-columns: minmax(0, 1.15fr) minmax(280px, 0.85fr);
+  gap: 2rem;
+  align-items: stretch;
+  padding: 4rem 0 3rem;
+}
+
+.hero-copy,
+.hero-card,
+.panel,
+.service-card,
+.step,
+.promise,
+.price-card {
+  background: rgba(255, 255, 255, 0.84);
+  border: 1px solid var(--line);
+  border-radius: 28px;
+  box-shadow: var(--shadow);
+}
+
+.hero-copy {
+  padding: clamp(2rem, 5vw, 4rem);
+}
+
+.eyebrow {
+  display: inline-flex;
+  border-radius: 999px;
+  padding: 0.45rem 0.8rem;
+  margin-bottom: 1rem;
+  background: var(--accent);
+  color: var(--brand-dark);
+  font-weight: 800;
+  letter-spacing: 0.02em;
+}
+
+.hero h1 {
+  font-size: clamp(2.5rem, 7vw, 5.7rem);
+  line-height: 0.95;
+  letter-spacing: -0.07em;
+  margin: 0 0 1rem;
+}
+
+.hero p.lede,
+.section-lede {
+  color: var(--muted);
+  font-size: clamp(1.12rem, 2vw, 1.35rem);
+  line-height: 1.65;
+}
+
+.hero-actions,
+.card-actions {
+  display: flex;
+  gap: 0.8rem;
+  flex-wrap: wrap;
+  margin-top: 1.5rem;
+}
+
+.hero-card {
+  padding: 2rem;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  background: linear-gradient(160deg, #10231f 0%, #123d34 55%, #10a37f 130%);
+  color: #fff;
+}
+
+.hero-card h2,
+.hero-card h3,
+.hero-card p,
+.hero-card li {
+  color: #fff;
+}
+
+.status-pill {
+  width: fit-content;
+  border: 1px solid rgba(255,255,255,0.22);
+  border-radius: 999px;
+  padding: 0.5rem 0.8rem;
+  background: rgba(255,255,255,0.12);
+}
+
+.grid-3,
+.grid-2,
+.steps {
+  display: grid;
+  gap: 1rem;
+  margin: 1.5rem 0 3rem;
+}
+
+.grid-3 { grid-template-columns: repeat(3, 1fr); }
+.grid-2 { grid-template-columns: repeat(2, 1fr); }
+.steps { grid-template-columns: repeat(5, 1fr); }
+
+.panel,
+.service-card,
+.step,
+.promise,
+.price-card {
+  padding: 1.5rem;
+}
+
+.service-card h3,
+.price-card h3,
+.promise h3 {
+  margin-top: 0;
+}
+
+.icon {
+  font-size: 1.8rem;
+}
+
+.price {
+  font-size: 2rem;
+  font-weight: 900;
+  color: var(--brand-dark);
+}
+
+.cta-band {
+  border-radius: 32px;
+  padding: clamp(2rem, 5vw, 3.25rem);
+  background: var(--ink);
+  color: #fff;
+  box-shadow: var(--shadow);
+  margin: 3rem 0;
+}
+
+.cta-band h2,
+.cta-band p {
+  color: #fff;
+}
+
+@media (max-width: 860px) {
+  .hero,
+  .grid-3,
+  .grid-2,
+  .steps {
+    grid-template-columns: 1fr;
+  }
+
+  .site-nav {
+    align-items: flex-start;
+    flex-direction: column;
+  }
+}

--- a/index.md
+++ b/index.md
@@ -3,90 +3,74 @@ title: "Kai’s Tech Services — Remote IT Support & Security"
 layout: default
 ---
 
-# Kai’s Tech Services
+<nav class="site-nav">
+  <a class="brand-mark" href="/"><span class="logo-dot">KJ</span><span>Kai’s Tech Services</span></a>
+  <div class="nav-links">
+    <a href="/services">Services</a>
+    <a href="mailto:kvjones0243@gmail.com">Email</a>
+    <a href="https://docs.google.com/forms/d/e/1FAIpQLSdyKiftIgcJzweKwpwo3SDnVfIdkEDmz1z0zy9CWlV2RoB0sg/viewform?usp=dialog">Request Support</a>
+  </div>
+</nav>
 
-**Remote IT Support • Security Setup • Microsoft 365 Help**  
-Las Vegas, NV (Remote-First)
+<section class="hero">
+  <div class="hero-copy">
+    <span class="eyebrow">Remote-first IT support • Las Vegas, NV</span>
+    <h1>Calm, secure tech help when your devices get loud.</h1>
+    <p class="lede">I help individuals and small businesses fix computer, Wi‑Fi, Microsoft 365, and account-security problems with plain-English support and clean documentation.</p>
+    <div class="hero-actions">
+      <a class="button" href="https://docs.google.com/forms/d/e/1FAIpQLSdyKiftIgcJzweKwpwo3SDnVfIdkEDmz1z0zy9CWlV2RoB0sg/viewform?usp=dialog">Request Support</a>
+      <a class="secondary-button" href="/services">View Services</a>
+    </div>
+  </div>
+  <aside class="hero-card">
+    <div>
+      <span class="status-pill">Now booking remote sessions</span>
+      <h2>Fast fixes. Safer setups. Less stress.</h2>
+      <p>Every session focuses on the immediate issue, the root cause, and the next best prevention step.</p>
+    </div>
+    <ul>
+      <li>Quick response and clear communication</li>
+      <li>Security-first setup for accounts, devices, and Wi‑Fi</li>
+      <li>Session summary with next-step recommendations</li>
+    </ul>
+  </aside>
+</section>
 
-**I take care of your tech so you can focus on your life or business — without the stress.**
+<section>
+  <span class="eyebrow">What I do</span>
+  <h2>Practical support for the tech you use every day.</h2>
+  <p class="section-lede">No mystery fixes or confusing jargon — just focused troubleshooting, secure configuration, and guidance you can actually use.</p>
+  <div class="grid-3">
+    <article class="service-card"><div class="icon">🛠️</div><h3>Remote Troubleshooting</h3><p>Slow PCs, app errors, printer issues, email problems, and everyday device headaches.</p></article>
+    <article class="service-card"><div class="icon">🔐</div><h3>Security Setup</h3><p>MFA, password managers, browser cleanup, safe sign-in habits, and device hardening.</p></article>
+    <article class="service-card"><div class="icon">☁️</div><h3>Microsoft 365 Help</h3><p>Outlook, account access, admin basics, user setup, MFA issues, and email configuration.</p></article>
+  </div>
+</section>
 
-**Get Started:** [Request Support](https://docs.google.com/forms/d/e/1FAIpQLSdyKiftIgcJzweKwpwo3SDnVfIdkEDmz1z0zy9CWlV2RoB0sg/viewform?usp=dialog)  
-**Email:** [kvjones0243@gmail.com](mailto:kvjones0243@gmail.com)
+<section>
+  <span class="eyebrow">How support works</span>
+  <h2>A simple process from intake to resolution.</h2>
+  <div class="steps">
+    <div class="step"><strong>01</strong><p>Fill out the support form with your issue.</p></div>
+    <div class="step"><strong>02</strong><p>I review the details and confirm scope.</p></div>
+    <div class="step"><strong>03</strong><p>We schedule a secure remote session.</p></div>
+    <div class="step"><strong>04</strong><p>I troubleshoot, fix, and explain the changes.</p></div>
+    <div class="step"><strong>05</strong><p>You receive a summary and recommendations.</p></div>
+  </div>
+</section>
 
----
+<section class="grid-3">
+  <article class="promise"><h3>No Tech Talk</h3><p>I explain what changed in plain English so you know what happened and why.</p></article>
+  <article class="promise"><h3>No Pressure</h3><p>You will know the scope before work starts, with honest guidance for next steps.</p></article>
+  <article class="promise"><h3>Security First</h3><p>Fixing today’s problem matters. Preventing the next one matters even more.</p></article>
+</section>
 
-## 5-Star Support, Built on Real IT Experience
-
-I provide fast, clear, and professional tech support with a security-first mindset.
-No confusing jargon. No mystery fixes. Just clean results.
-
-**What you can expect:**
-- Quick response and clear communication
-- Remote-first troubleshooting (fast + efficient)
-- Secure setup practices (accounts, devices, and Wi-Fi)
-- Documentation and next steps after every session
-
----
-
-## IT Services & Support
-
-Simple, reliable services designed for real people and small businesses.
-
-### Managed Support (Lightweight)
-Keep your devices stable and protected with proactive checkups and maintenance.
-
-### Microsoft 365 Setup & Fixes
-Login issues, MFA, account cleanup, Outlook/email problems, and admin support.
-
-### Wi-Fi & Network Troubleshooting
-Slow internet, disconnects, router setup, mesh systems, and stability fixes.
-
-### Security & Account Protection
-MFA setup, password manager setup, safe browsing, device hardening.
-
-### PC Performance & Cleanup
-Slow PC fixes, startup cleanup, storage cleanup, updates, and optimization.
-
----
-
-## How Support Works
-
-Here’s the simple process:
-
-1. **You fill out the support form**
-2. **I review your issue and contact you**
-3. **We schedule a remote session**
-4. **I troubleshoot + fix the issue**
-5. **You get a clear summary + recommendations**
-
-**Start here:** [Request Support](https://docs.google.com/forms/d/e/1FAIpQLSdyKiftIgcJzweKwpwo3SDnVfIdkEDmz1z0zy9CWlV2RoB0sg/viewform?usp=dialog)
-
----
-
-## My Support Promise
-
-**No Tech Talk**  
-I explain things in plain English. You’ll know what changed and why.
-
-**No Pressure**  
-You’ll always know the scope before work starts.
-
-**Security-First**  
-Fixing the problem is good. Preventing the next one is better.
-
----
-
-## Testimonials (Coming Soon)
-
-Client reviews will be posted here after completed sessions.
-
-If you’ve worked with me and want to leave a review, email me at:  
-[kvjones0243@gmail.com](mailto:kvjones0243@gmail.com)
-
----
-
-## Contact
-
-**Email:** [kvjones0243@gmail.com](mailto:kvjones0243@gmail.com)  
-**Request Support:** [Support Intake Form](https://docs.google.com/forms/d/e/1FAIpQLSdyKiftIgcJzweKwpwo3SDnVfIdkEDmz1z0zy9CWlV2RoB0sg/viewform?usp=dialog)  
-**LinkedIn:** [linkedin.com/in/kaijones23](https://www.linkedin.com/in/kaijones23)
+<section class="cta-band">
+  <span class="eyebrow">Ready when you are</span>
+  <h2>Tell me what is going wrong, and I’ll help you get back on track.</h2>
+  <p>Use the intake form for the fastest response, or email me directly at <a href="mailto:kvjones0243@gmail.com">kvjones0243@gmail.com</a>.</p>
+  <div class="hero-actions">
+    <a class="button" href="https://docs.google.com/forms/d/e/1FAIpQLSdyKiftIgcJzweKwpwo3SDnVfIdkEDmz1z0zy9CWlV2RoB0sg/viewform?usp=dialog">Start Intake Form</a>
+    <a class="secondary-button" href="https://www.linkedin.com/in/kaijones23">LinkedIn</a>
+  </div>
+</section>

--- a/services.md
+++ b/services.md
@@ -3,144 +3,66 @@ title: "Services — Kai’s Tech Services"
 layout: default
 ---
 
-# Services
+<nav class="site-nav">
+  <a class="brand-mark" href="/"><span class="logo-dot">KJ</span><span>Kai’s Tech Services</span></a>
+  <div class="nav-links">
+    <a href="/">Home</a>
+    <a href="mailto:kvjones0243@gmail.com">Email</a>
+    <a href="https://docs.google.com/forms/d/e/1FAIpQLSdyKiftIgcJzweKwpwo3SDnVfIdkEDmz1z0zy9CWlV2RoB0sg/viewform?usp=dialog">Request Support</a>
+  </div>
+</nav>
 
-**Remote-first IT support that's fast, secure, and straightforward.**
+<section class="hero">
+  <div class="hero-copy">
+    <span class="eyebrow">Services & pricing</span>
+    <h1>Clear options for quick fixes, safer devices, and small-business support.</h1>
+    <p class="lede">Choose a session or setup package, then submit the intake form so I can confirm scope and schedule the right remote support window.</p>
+    <div class="hero-actions">
+      <a class="button" href="https://docs.google.com/forms/d/e/1FAIpQLSdyKiftIgcJzweKwpwo3SDnVfIdkEDmz1z0zy9CWlV2RoB0sg/viewform?usp=dialog">Request Support</a>
+      <a class="secondary-button" href="mailto:kvjones0243@gmail.com">Ask a Question</a>
+    </div>
+  </div>
+  <aside class="hero-card">
+    <span class="status-pill">Remote-first support</span>
+    <h2>Best fit for Windows PCs, home Wi‑Fi, Microsoft 365, printers, and account security.</h2>
+    <p>Payment is collected before the session begins, and every appointment includes a written summary.</p>
+  </aside>
+</section>
 
-Kai's Tech Services helps individuals and small businesses stay productive and protected. No confusing jargon. No surprise bills. Just clear solutions and honest communication.
+<section>
+  <span class="eyebrow">Most popular</span>
+  <h2>Session-based support</h2>
+  <div class="grid-2">
+    <article class="price-card"><h3>Quick Fix Session</h3><div class="price">$60 / 45 min</div><p>Best for slow PCs, Wi‑Fi issues, printer setup, email/login issues, app errors, and installations.</p><ul><li>Remote troubleshooting and resolution</li><li>Summary of what was fixed and why</li></ul></article>
+    <article class="price-card"><h3>Extended Fix Session</h3><div class="price">$90 / 90 min</div><p>Best for multiple issues, complex performance problems, device setup plus cleanup, or deeper Microsoft 365 issues.</p><ul><li>Complete troubleshooting session</li><li>Cleanup, configuration fixes, and next-step recommendations</li></ul></article>
+  </div>
+</section>
 
-**[→ Request Support (Intake Form)](https://docs.google.com/forms/d/e/1FAIpQLSdyKiftIgcJzweKwpwo3SDnVfIdkEDmz1z0zy9CWlV2RoB0sg/viewform?usp=dialog)**  
-**[Email: kvjones0243@gmail.com](mailto:kvjones0243@gmail.com)**
+<section>
+  <span class="eyebrow">Security & setup</span>
+  <h2>Flat-rate packages</h2>
+  <div class="grid-2">
+    <article class="price-card"><h3>Security Baseline Setup</h3><div class="price">From $120</div><p>MFA setup, Bitwarden password manager setup, browser cleanup, device-security recommendations, and one follow-up check-in.</p></article>
+    <article class="price-card"><h3>New Computer Setup</h3><div class="price">From $120</div><p>System updates, essential configuration, app setup, account sign-in, OneDrive or Google Drive backup, and a basic security walkthrough.</p></article>
+  </div>
+</section>
 
----
+<section>
+  <span class="eyebrow">Small business</span>
+  <h2>Hourly support for growing teams.</h2>
+  <div class="grid-2">
+    <article class="price-card"><h3>Microsoft 365 Help</h3><div class="price">$90–$150/hr</div><p>User setup/removal, MFA troubleshooting, Outlook configuration, security improvements, and admin best practices.</p></article>
+    <article class="price-card"><h3>Business Wi‑Fi & Network Support</h3><div class="price">$90–$150/hr</div><p>Wi‑Fi stability, mesh optimization, router configuration, VPN, and remote-connectivity troubleshooting.</p></article>
+  </div>
+</section>
 
-## Session-Based Support (Most Popular)
+<section class="grid-2">
+  <article class="panel"><h2>What I support</h2><ul><li>Windows PCs as the primary focus</li><li>Basic macOS and Android support</li><li>Home Wi‑Fi and small office networking</li><li>Microsoft 365 setup and troubleshooting</li><li>Printers and common peripherals</li><li>Hardware repair, including soldering and component-level repair</li></ul></article>
+  <article class="panel"><h2>Out of scope</h2><p>To maintain quality and focus on legitimate support, I do not assist with illegal or pirated software.</p><h3>Response time</h3><p>Email or submit the intake form — I respond within 24 hours.</p></article>
+</section>
 
-### Quick Fix Session
-**$60 / 45 minutes**
-
-Best for:
-- Slow PC troubleshooting
-- Wi-Fi or internet issues
-- Printer setup & problems
-- Email and login issues
-- App errors and installation help
-
-What's included:
-- Remote troubleshooting and resolution
-- Summary of what was fixed and why
-
----
-
-### Extended Fix Session
-**$90 / 90 minutes**
-
-Best for:
-- Multiple issues that need time
-- Complex performance problems
-- Device setup plus cleanup
-- Microsoft 365 account issues requiring deeper investigation
-
-What's included:
-- Complete troubleshooting session
-- System cleanup and configuration fixes
-- Next-step recommendations for ongoing stability
-
----
-
-## Security & Setup Services
-
-### Security Baseline Setup
-**Starting at $120 (flat rate)**
-
-Best for:
-- Account security upgrades
-- New device protection setup
-- Preventing hacks and lockouts
-
-What's included:
-- MFA setup (Google and Microsoft accounts)
-- Password manager setup (Bitwarden recommended)
-- Browser security hardening and cleanup
-- Device security recommendations
-- One follow-up check-in
-
----
-
-### New Computer Setup
-**Starting at $120 (flat rate)**
-
-Best for:
-- New laptop or desktop setup
-- Fresh OS installation and configuration
-- New device onboarding
-
-What's included:
-- System updates and essential configuration
-- Apps installed and configured
-- Account sign-in and verification
-- Backup setup (OneDrive or Google Drive)
-- Basic security walkthrough
-
----
-
-## Small Business IT Support
-
-### Microsoft 365 Help (Small Business)
-**$90–$150/hour (based on scope)**
-
-Common requests:
-- User account setup and removal
-- MFA and login troubleshooting
-- Email and Outlook configuration
-- Security improvements and audit
-- Admin best practices and guidance
-
----
-
-### Business Wi-Fi & Network Support
-**$90–$150/hour**
-
-Common requests:
-- Wi-Fi stability and performance issues
-- Mesh network setup and optimization
-- Router configuration and security
-- VPN and remote connectivity troubleshooting
-
----
-
-## What I Support
-
-- Windows PCs (primary focus)
-- Basic macOS support
-- Home Wi-Fi and small office networking
-- Microsoft 365 setup and troubleshooting
-- Printers and common peripherals
-- Android devices (basic support)
-- Hardware repair (soldering, component-level repair)
-
----
-
-## Out of Scope
-
-To maintain quality and focus on legitimate support, I don't assist with:
-- Illegal or pirated software
-
----
-
-## How It Works
-
-1. **Fill out the intake form** with details about your issue
-2. **I contact you** to confirm the scope and schedule a time
-3. **Payment is collected** before the session begins
-4. **Remote troubleshooting** — I remote in and solve the problem
-5. **You get a summary** with what was fixed and any next steps
-
-**→ [Request Support (Intake Form)](https://docs.google.com/forms/d/e/1FAIpQLSdyKiftIgcJzweKwpwo3SDnVfIdkEDmz1z0zy9CWlV2RoB0sg/viewform?usp=dialog)**
-
----
-
-## Have Questions?
-
-**Email:** [kvjones0243@gmail.com](mailto:kvjones0243@gmail.com)  
-**Or use the intake form above** — I respond within 24 hours
+<section class="cta-band">
+  <h2>Ready to schedule?</h2>
+  <p>Start with the intake form and I’ll follow up with scope, timing, and next steps.</p>
+  <a class="button" href="https://docs.google.com/forms/d/e/1FAIpQLSdyKiftIgcJzweKwpwo3SDnVfIdkEDmz1z0zy9CWlV2RoB0sg/viewform?usp=dialog">Request Support</a>
+</section>


### PR DESCRIPTION
### Motivation
- Modernize the portfolio to a ChatGPT Sites–inspired, conversion-focused layout with clearer navigation, hero messaging, and service pricing. 
- Improve visual hierarchy and branding with a cohesive green/white system, card-based content, and mobile-first responsiveness.

### Description
- Rewrote the homepage (`index.md`) into a component-style landing layout with a site nav, hero section, service cards, a 5-step process, trust promises, and a CTA band. 
- Rebuilt the services page (`services.md`) with pricing cards, session/package sections, scope notes, and clearer CTAs. 
- Added `assets/css/style.scss` which overrides the Cayman theme and provides the new color tokens, card styles, buttons, responsive grid layouts, and hero visuals. 
- Kept front matter intact for both pages and ensured the new styles are placed under `assets/css` for Jekyll consumption.

### Testing
- `python3` front matter/content smoke check validated that `index.md`, `services.md`, `_config.yml`, and `assets/css/style.scss` contain expected front matter and content and passed. 
- `jekyll build` could not be executed because Jekyll is not installed in the execution environment, so site build was not run here. 
- Attempting `bundle install` with a temporary `Gemfile` failed due to `rubygems.org` returning `403 Forbidden`, so no dependency install or local build was completed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5bbb82d4488332964937bd24de62fa)