### PR TITLE
site: Add DeafBench product demo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+*.py[cod]

--- a/index.html
+++ b/index.html
@@ -62,7 +62,7 @@
       <div class="section-intro">
         <p class="section-label">DeafBench results</p>
         <h2 id="evidence-title">What the numbers show</h2>
-        <p>These are local, reproducible results on DeafBench synthetic-v2: 25 samples built around names, times, codes, addresses, and other details that matter.</p>
+        <p>These are recorded local observations on DeafBench synthetic-v2: 25 samples built around names, times, codes, addresses, and other details that matter. The metadata is published, but the sample-level run artifacts are not, so these values cannot be independently recomputed from this site or a repository checkout.</p>
       </div>
       <div class="table-wrap" tabindex="0" aria-label="Scrollable DeafBench model results">
         <table>

--- a/index.html
+++ b/index.html
@@ -37,12 +37,13 @@
     <section class="work-grid ruled" id="work" aria-labelledby="work-title">
       <h2 id="work-title" class="sr-only">Work</h2>
       <article class="work-item feature-work">
-        <h3><a href="https://github.com/488315/DeafBench">DeafBench</a></h3>
+        <h3><a href="/products/deafbench/">DeafBench</a></h3>
         <p>DeafBench checks whether speech recognition preserves the information a person actually needs—not only whether the words look close.</p>
         <figure class="cli-figure">
           <img src="/assets/images/deafbench-cli.png" width="960" height="540" alt="DeafBench command-line evaluation showing word error rate, critical-information recall, non-speech recall, speaker attribution, latency, and three detected critical-information failures.">
           <figcaption>Real output from <code>deafbench compare</code> on the public example files.</figcaption>
         </figure>
+        <p><a class="text-link" href="/products/deafbench/">See the benchmark demo →</a></p>
       </article>
 
       <article class="work-item">
@@ -74,7 +75,7 @@
           </tbody>
         </table>
       </div>
-      <p class="data-note">Canonical semantic recall is shown. These are local benchmark results, not endorsements or a public leaderboard ranking. <a href="https://github.com/488315/DeafBench/tree/main/experiments/model-results">See the model evidence</a>.</p>
+      <p class="data-note">Canonical semantic recall is shown. These are local benchmark results, not endorsements or a public leaderboard ranking. <a href="/products/deafbench/">See all integrated models and evidence boundaries</a>.</p>
     </section>
 
     <section class="notes ruled" aria-labelledby="notes-title">

--- a/products/deafbench/index.html
+++ b/products/deafbench/index.html
@@ -1,0 +1,149 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>DeafBench — accessibility-critical ASR evaluation</title>
+  <meta name="description" content="A public demonstration of DeafBench, an ASR benchmark that measures word errors, critical-information failures, acoustic stress, and local performance without treating unlike evidence as comparable.">
+  <link rel="canonical" href="https://488315.github.io/products/deafbench/">
+  <meta property="og:title" content="DeafBench — accessibility-critical ASR evaluation">
+  <meta property="og:description" content="See what DeafBench measures, which models run, and which results are still missing.">
+  <meta property="og:type" content="website">
+  <meta property="og:url" content="https://488315.github.io/products/deafbench/">
+  <link rel="stylesheet" href="/styles.css">
+</head>
+<body>
+  <a class="skip-link" href="#main">Skip to content</a>
+  <header class="site-header">
+    <div class="wrap nav-wrap">
+      <a class="wordmark" href="/" aria-label="Kai Jones, home">Kai Jones</a>
+      <nav aria-label="Primary navigation">
+        <a href="/">Home</a>
+        <a href="/writing/">Writing</a>
+        <a class="nav-contact" href="https://github.com/488315/DeafBench">Source</a>
+      </nav>
+    </div>
+  </header>
+
+  <main id="main" class="wrap product-shell">
+    <header class="product-hero">
+      <p class="section-label">DeafBench</p>
+      <h1>I test what an ASR system drops when the detail matters.</h1>
+      <p class="product-lede">I wrote DeafBench because a transcript can look mostly right and still lose a time, a username, a dosage, or the word “not.” It keeps ordinary word error rate, but it also scores those failures directly and records the exact evidence behind a result.</p>
+      <div class="product-actions">
+        <a class="button-link" href="https://github.com/488315/DeafBench">Read the code</a>
+        <a class="text-link" href="#demo">See the public demo ↓</a>
+      </div>
+    </header>
+
+    <section class="ruled demo-boundary" aria-labelledby="boundary-title">
+      <div>
+        <p class="section-label">Evidence boundary</p>
+        <h2 id="boundary-title">Synthetic accessibility stress demo</h2>
+      </div>
+      <div>
+        <p>This demonstration uses DeafBench’s authorized synthetic corpus. It tests whether model output preserves declared critical details while audio is changed in controlled ways. It does not measure Deaf or hard-of-hearing speakers, dysarthric speech, accents, age groups, or any other human demographic.</p>
+        <p>Those questions need authorized, consented, appropriately licensed human speech, declared cohorts, sample sizes, uncertainty, and disjoint development and evaluation sets. I will not substitute a synthetic voice effect for that evidence.</p>
+      </div>
+    </section>
+
+    <section class="ruled" id="demo" aria-labelledby="demo-title">
+      <div class="section-intro product-intro">
+        <p class="section-label">What gets stressed</p>
+        <h2 id="demo-title">The details and conditions are declared before a model runs.</h2>
+        <p>Every row below describes a failure DeafBench can count separately from overall WER. The full frozen suite contains 24 utterances and gives each clean reference a controlled stress condition.</p>
+      </div>
+      <div class="scenario-grid">
+        <article><p class="scenario-type">Time</p><p>“The appointment is at 8:30 p.m.”</p></article>
+        <article><p class="scenario-type">Date</p><p>“The deadline is November 14.”</p></article>
+        <article><p class="scenario-type">Dosage</p><p>“Take 12 milligrams at noon.”</p></article>
+        <article><p class="scenario-type">Name</p><p>“Ask for Nia Solano at reception.”</p></article>
+        <article><p class="scenario-type">Username</p><p>“The username is kai.jones_27.”</p></article>
+        <article><p class="scenario-type">Code</p><p>“The access code is H7Q9.”</p></article>
+        <article><p class="scenario-type">Confirmation number</p><p>“The confirmation number is 804193.”</p></article>
+        <article><p class="scenario-type">Wi-Fi name</p><p>“Connect to North Hall Guest.”</p></article>
+        <article><p class="scenario-type">Address</p><p>“Meet at 214 Cedar Avenue.”</p></article>
+        <article><p class="scenario-type">Money</p><p>“The total is $46.20.”</p></article>
+        <article><p class="scenario-type">Negation</p><p>“Do not take the west entrance.”</p></article>
+      </div>
+      <div class="stress-strip" aria-label="Declared acoustic stress conditions">
+        <p><strong>Noise:</strong> street, office chatter, keyboard, breathing, rustling, and wind at −5, 0, 10, and 20 dB SNR.</p>
+        <p><strong>Signal changes:</strong> 8 kHz telephony, reverberation, long intra-phrase pauses, and speaking-rate variation.</p>
+        <p><strong>Tracked failures:</strong> substitutions, insertions, deletions, hallucinations in interstitial noise, critical-entity misses, and caption timestamp drift over 500 ms.</p>
+      </div>
+    </section>
+
+    <section class="ruled" aria-labelledby="results-title">
+      <div class="section-intro product-intro">
+        <p class="section-label">Comparable lane</p>
+        <h2 id="results-title">Synthetic-v2 results</h2>
+        <p>These seven models ran the same 25-sample local corpus. Canonical recall accepts harmless representation differences but does not fuzzy-match usernames, codes, Wi-Fi names, incomplete numbers, or wrong times.</p>
+      </div>
+      <div class="table-wrap" tabindex="0" aria-label="Scrollable synthetic-v2 model results">
+        <table>
+          <thead><tr><th>Model</th><th>WER</th><th>Strict recall</th><th>Canonical recall</th><th>Local RTFx</th><th>Peak VRAM</th></tr></thead>
+          <tbody>
+            <tr><td>Qwen3-ASR 0.6B</td><td>26.6%</td><td>67.7%</td><td>90.3%</td><td>10.47</td><td>1.52 GiB</td></tr>
+            <tr><td>Qwen3-ASR 1.7B</td><td>21.0%</td><td>67.7%</td><td>91.9%</td><td>9.89</td><td>3.86 GiB</td></tr>
+            <tr><td>Parakeet TDT 0.6B v2</td><td>22.7%</td><td>64.5%</td><td>91.9%</td><td>71.23</td><td>4.67 GiB</td></tr>
+            <tr><td>Granite Speech 4.1 2B</td><td>18.9%</td><td>69.4%</td><td>91.9%</td><td>12.91</td><td>4.35 GiB</td></tr>
+            <tr><td>Granite Speech 4.1 2B NAR</td><td>40.6%</td><td>64.5%</td><td>87.1%</td><td>45.07</td><td>4.26 GiB</td></tr>
+            <tr><td>ARK-ASR 0.6B</td><td>30.1%</td><td>66.1%</td><td>90.3%</td><td>14.85</td><td>2.20 GiB</td></tr>
+            <tr><td>ARK-ASR 0.6B INT8 ONNX</td><td>26.6%</td><td>66.1%</td><td>90.3%</td><td>2.40</td><td>CPU</td></tr>
+          </tbody>
+        </table>
+      </div>
+      <p class="data-note product-note">Local RTFx and VRAM depend on the test computer. This is a synthetic accessibility lane, not a Hugging Face leaderboard result and not a ranking across unlike datasets.</p>
+    </section>
+
+    <section class="ruled" aria-labelledby="inventory-title">
+      <div class="section-intro product-intro">
+        <p class="section-label">Complete inventory</p>
+        <h2 id="inventory-title">All eleven integrated model paths</h2>
+        <p>“Integrated” means DeafBench has an adapter or runner. It does not mean every model has comparable completed evidence. Missing results stay missing.</p>
+      </div>
+      <div class="table-wrap" tabindex="0" aria-label="Scrollable integrated model inventory">
+        <table>
+          <thead><tr><th>Model</th><th>Evidence currently shown</th><th>Lane</th></tr></thead>
+          <tbody>
+            <tr><td>OpenAI Whisper turbo</td><td>Completed historical reports</td><td>Core v1 and non-speech v1</td></tr>
+            <tr><td>Faster-Whisper small.en</td><td>Completed frozen and development baselines</td><td>Core v1 and public real-speech dev</td></tr>
+            <tr><td>Whisper-AT medium.en</td><td>Result not completed</td><td>Adapter and workflow only</td></tr>
+            <tr><td>Distil-Whisper large-v3</td><td>Result not completed</td><td>Adapter and local runner only</td></tr>
+            <tr><td>Qwen3-ASR 0.6B</td><td>Completed</td><td>Synthetic-v2 and real-speech smoke</td></tr>
+            <tr><td>Qwen3-ASR 1.7B</td><td>Completed</td><td>Synthetic-v2 and real-speech smoke</td></tr>
+            <tr><td>Parakeet TDT 0.6B v2</td><td>Completed</td><td>Synthetic-v2 and real-speech smoke</td></tr>
+            <tr><td>Granite Speech 4.1 2B</td><td>Completed</td><td>Synthetic-v2 and real-speech smoke</td></tr>
+            <tr><td>Granite Speech 4.1 2B NAR</td><td>Completed</td><td>Synthetic-v2 and real-speech smoke</td></tr>
+            <tr><td>ARK-ASR 0.6B</td><td>Completed</td><td>Synthetic-v2 and real-speech smoke</td></tr>
+            <tr><td>ARK-ASR 0.6B INT8 ONNX</td><td>Completed</td><td>Synthetic-v2 and real-speech smoke</td></tr>
+          </tbody>
+        </table>
+      </div>
+    </section>
+
+    <section class="ruled goal-grid" aria-labelledby="goal-title">
+      <div>
+        <p class="section-label">Real-speech goal</p>
+        <h2 id="goal-title">The target is the Open ASR Leaderboard contract, not a convenient local score.</h2>
+      </div>
+      <div>
+        <p>DeafBench has a separate official-compatible real-speech path and a deterministic 100-sample public development cohort. The current Faster-Whisper <code>small.en</code> development baseline is 3.56% normalized WER on that cohort. It is development evidence, not the seven-dataset leaderboard macro-average.</p>
+        <p>The long-term goal is to beat the published 5.37% average WER reference under the official dataset revisions, preprocessing, normalization, macro-average, and submission rules. I will not claim that result unless Hugging Face verifies it.</p>
+      </div>
+    </section>
+
+    <section class="ruled pilot-status" aria-labelledby="pilot-title">
+      <p class="section-label">Customer-run audit</p>
+      <h2 id="pilot-title">The audit is designed to run on the customer’s computer.</h2>
+      <p>Audio stays with the customer. Exported evidence is limited to sanitized aggregate metrics, environment-dependent labels, model and evaluator identifiers, configuration, counts, and artifact hashes. Raw audio, transcripts, filenames, paths, identities, secrets, and critical-information values are excluded by a fail-closed scanner.</p>
+      <p><strong>Status:</strong> the workflow is still being validated. I am not accepting customer audio or payment yet.</p>
+    </section>
+  </main>
+
+  <footer class="site-footer">
+    <div class="wrap footer-wrap"><p>© <span id="year">2026</span> Kai Jones</p><p><a href="https://github.com/488315/DeafBench">DeafBench source</a> · <a href="/writing/why-deafbench/">Why I made it</a></p></div>
+  </footer>
+  <script>document.getElementById('year').textContent = new Date().getFullYear();</script>
+</body>
+</html>

--- a/products/deafbench/index.html
+++ b/products/deafbench/index.html
@@ -77,7 +77,7 @@
       <div class="section-intro product-intro">
         <p class="section-label">Comparable lane</p>
         <h2 id="results-title">Synthetic-v2 results</h2>
-        <p>These seven models ran the same 25-sample local corpus. Canonical recall accepts harmless representation differences but does not fuzzy-match usernames, codes, Wi-Fi names, incomplete numbers, or wrong times.</p>
+        <p>These nine models ran the same 25-sample local corpus. Canonical recall accepts harmless representation differences but does not fuzzy-match usernames, codes, Wi-Fi names, incomplete numbers, or wrong times.</p>
       </div>
       <div class="table-wrap" tabindex="0" aria-label="Scrollable synthetic-v2 model results">
         <table>
@@ -90,6 +90,8 @@
             <tr><td>Granite Speech 4.1 2B NAR</td><td>40.6%</td><td>64.5%</td><td>87.1%</td><td>45.07</td><td>4.26 GiB</td></tr>
             <tr><td>ARK-ASR 0.6B</td><td>30.1%</td><td>66.1%</td><td>90.3%</td><td>14.85</td><td>2.20 GiB</td></tr>
             <tr><td>ARK-ASR 0.6B INT8 ONNX</td><td>26.6%</td><td>66.1%</td><td>90.3%</td><td>2.40</td><td>CPU</td></tr>
+            <tr><td>Distil-Whisper large-v3</td><td>23.8%</td><td>66.1%</td><td>91.9%</td><td>0.80</td><td>CPU</td></tr>
+            <tr><td>Whisper-AT medium.en</td><td>26.2%</td><td>67.7%</td><td>96.8%</td><td>7.34</td><td>4.46 GiB</td></tr>
           </tbody>
         </table>
       </div>
@@ -108,8 +110,8 @@
           <tbody>
             <tr><td>OpenAI Whisper turbo</td><td>Completed historical reports</td><td>Core v1 and non-speech v1</td></tr>
             <tr><td>Faster-Whisper small.en</td><td>Completed frozen and development baselines</td><td>Core v1 and public real-speech dev</td></tr>
-            <tr><td>Whisper-AT medium.en</td><td>Result not completed</td><td>Adapter and workflow only</td></tr>
-            <tr><td>Distil-Whisper large-v3</td><td>Result not completed</td><td>Adapter and local runner only</td></tr>
+            <tr><td>Whisper-AT medium.en</td><td>Completed</td><td>Synthetic-v2, real-speech smoke, and non-speech-v1</td></tr>
+            <tr><td>Distil-Whisper large-v3</td><td>Completed</td><td>Synthetic-v2 and real-speech smoke</td></tr>
             <tr><td>Qwen3-ASR 0.6B</td><td>Completed</td><td>Synthetic-v2 and real-speech smoke</td></tr>
             <tr><td>Qwen3-ASR 1.7B</td><td>Completed</td><td>Synthetic-v2 and real-speech smoke</td></tr>
             <tr><td>Parakeet TDT 0.6B v2</td><td>Completed</td><td>Synthetic-v2 and real-speech smoke</td></tr>

--- a/products/deafbench/index.html
+++ b/products/deafbench/index.html
@@ -77,7 +77,7 @@
       <div class="section-intro product-intro">
         <p class="section-label">Comparable lane</p>
         <h2 id="results-title">Synthetic-v2 results</h2>
-        <p>These nine models ran the same 25-sample local corpus. Canonical recall accepts harmless representation differences but does not fuzzy-match usernames, codes, Wi-Fi names, incomplete numbers, or wrong times.</p>
+        <p>These nine rows are recorded local observations from the same 25-sample corpus. Their metadata manifests are byte-stable, but the sample-level run artifacts are not published in the repository, so the values cannot be independently recomputed from a checkout. Canonical recall accepts harmless representation differences but does not fuzzy-match usernames, codes, Wi-Fi names, incomplete numbers, or wrong times.</p>
       </div>
       <div class="table-wrap" tabindex="0" aria-label="Scrollable synthetic-v2 model results">
         <table>
@@ -110,15 +110,15 @@
           <tbody>
             <tr><td>OpenAI Whisper turbo</td><td>Completed historical reports</td><td>Core v1 and non-speech v1</td></tr>
             <tr><td>Faster-Whisper small.en</td><td>Completed frozen and development baselines</td><td>Core v1 and public real-speech dev</td></tr>
-            <tr><td>Whisper-AT medium.en</td><td>Completed</td><td>Synthetic-v2, real-speech smoke, and non-speech-v1</td></tr>
-            <tr><td>Distil-Whisper large-v3</td><td>Completed</td><td>Synthetic-v2 and real-speech smoke</td></tr>
-            <tr><td>Qwen3-ASR 0.6B</td><td>Completed</td><td>Synthetic-v2 and real-speech smoke</td></tr>
-            <tr><td>Qwen3-ASR 1.7B</td><td>Completed</td><td>Synthetic-v2 and real-speech smoke</td></tr>
-            <tr><td>Parakeet TDT 0.6B v2</td><td>Completed</td><td>Synthetic-v2 and real-speech smoke</td></tr>
-            <tr><td>Granite Speech 4.1 2B</td><td>Completed</td><td>Synthetic-v2 and real-speech smoke</td></tr>
-            <tr><td>Granite Speech 4.1 2B NAR</td><td>Completed</td><td>Synthetic-v2 and real-speech smoke</td></tr>
-            <tr><td>ARK-ASR 0.6B</td><td>Completed</td><td>Synthetic-v2 and real-speech smoke</td></tr>
-            <tr><td>ARK-ASR 0.6B INT8 ONNX</td><td>Completed</td><td>Synthetic-v2 and real-speech smoke</td></tr>
+            <tr><td>Whisper-AT medium.en</td><td>Recorded local observation</td><td>Synthetic-v2, real-speech smoke, and non-speech-v1</td></tr>
+            <tr><td>Distil-Whisper large-v3</td><td>Recorded local observation</td><td>Synthetic-v2 and real-speech smoke</td></tr>
+            <tr><td>Qwen3-ASR 0.6B</td><td>Recorded local observation</td><td>Synthetic-v2 and real-speech smoke</td></tr>
+            <tr><td>Qwen3-ASR 1.7B</td><td>Recorded local observation</td><td>Synthetic-v2 and real-speech smoke</td></tr>
+            <tr><td>Parakeet TDT 0.6B v2</td><td>Recorded local observation</td><td>Synthetic-v2 and real-speech smoke</td></tr>
+            <tr><td>Granite Speech 4.1 2B</td><td>Recorded local observation</td><td>Synthetic-v2 and real-speech smoke</td></tr>
+            <tr><td>Granite Speech 4.1 2B NAR</td><td>Recorded local observation</td><td>Synthetic-v2 and real-speech smoke</td></tr>
+            <tr><td>ARK-ASR 0.6B</td><td>Recorded local observation</td><td>Synthetic-v2 and real-speech smoke</td></tr>
+            <tr><td>ARK-ASR 0.6B INT8 ONNX</td><td>Recorded local observation</td><td>Synthetic-v2 and real-speech smoke</td></tr>
           </tbody>
         </table>
       </div>

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url><loc>https://488315.github.io/</loc></url>
+  <url><loc>https://488315.github.io/products/deafbench/</loc></url>
   <url><loc>https://488315.github.io/writing/</loc></url>
   <url><loc>https://488315.github.io/writing/why-deafbench/</loc></url>
   <url><loc>https://488315.github.io/writing/what-wer-misses/</loc></url>

--- a/styles.css
+++ b/styles.css
@@ -89,6 +89,32 @@ th { font-size: 13px; letter-spacing: .06em; text-transform: uppercase; }
 .article-body blockquote { margin: 32px 0; padding: 2px 0 2px 24px; border-left: 3px solid var(--blue); font-size: 25px; line-height: 1.5; }
 .article-body .callout { margin: 36px 0; padding: 22px 24px; border: 1px solid var(--line); font-family: Arial, Helvetica, sans-serif; font-size: 16px; }
 
+.product-shell { padding-bottom: 48px; }
+.product-hero { max-width: 1050px; padding: clamp(58px, 9vw, 120px) 0 clamp(52px, 7vw, 92px); }
+.product-hero h1 { max-width: 980px; margin: 0; font-size: clamp(48px, 7vw, 96px); line-height: .98; letter-spacing: -.055em; }
+.product-lede { max-width: 820px; margin: 28px 0 0; color: var(--muted); font-size: clamp(20px, 2vw, 27px); line-height: 1.45; }
+.product-actions { display: flex; align-items: center; flex-wrap: wrap; gap: 18px 30px; margin-top: 32px; }
+.button-link { display: inline-block; padding: 12px 18px; border: 2px solid var(--blue); color: white; background: var(--blue); font-size: 16px; font-weight: 700; text-decoration: none; }
+.button-link:hover { color: white; background: var(--blue-dark); border-color: var(--blue-dark); }
+.demo-boundary, .goal-grid { display: grid; grid-template-columns: .7fr 1.3fr; gap: clamp(32px, 7vw, 110px); }
+.demo-boundary h2, .goal-grid h2, .pilot-status h2 { margin: 0; font-size: clamp(28px, 3.5vw, 48px); line-height: 1.1; letter-spacing: -.035em; }
+.demo-boundary p:first-child, .goal-grid p:first-child { margin-top: 0; }
+.product-intro { display: grid; grid-template-columns: .55fr 1fr; column-gap: clamp(32px, 7vw, 110px); margin-bottom: 28px; }
+.product-intro .section-label { grid-row: 1 / span 2; }
+.product-intro h2 { margin: 0 0 10px; font-size: clamp(30px, 4vw, 52px); line-height: 1.08; letter-spacing: -.04em; }
+.product-intro p:last-child { max-width: 800px; margin: 0; }
+.scenario-grid { display: grid; grid-template-columns: repeat(4, 1fr); border-top: 1px solid var(--line); border-left: 1px solid var(--line); }
+.scenario-grid article { min-height: 145px; padding: 20px; border-right: 1px solid var(--line); border-bottom: 1px solid var(--line); }
+.scenario-grid p { margin: 0; }
+.scenario-grid .scenario-type { margin-bottom: 18px; color: var(--blue); font-size: 13px; font-weight: 700; letter-spacing: .07em; text-transform: uppercase; }
+.stress-strip { display: grid; grid-template-columns: repeat(3, 1fr); margin-top: 28px; border-top: 1px solid var(--line); border-bottom: 1px solid var(--line); }
+.stress-strip p { margin: 0; padding: 18px 24px; border-left: 1px solid var(--line); font-size: 15px; }
+.stress-strip p:first-child { padding-left: 0; border-left: 0; }
+.product-note { margin: 12px 0 0; }
+.goal-grid code { white-space: nowrap; }
+.pilot-status { max-width: 980px; }
+.pilot-status > p:not(.section-label) { max-width: 820px; }
+
 @media (max-width: 980px) {
   .work-grid { grid-template-columns: 1fr 1fr; }
   .feature-work { grid-column: 1 / -1; padding: 0 0 34px; margin-bottom: 32px; border-bottom: 1px solid var(--line); }
@@ -97,6 +123,7 @@ th { font-size: 13px; letter-spacing: .06em; text-transform: uppercase; }
   .data-note, .notes > p { grid-column: 1; margin-top: 0; }
   .values-contact { grid-template-columns: 1fr; }
   .contact-block { padding: 32px 0 0; border: 0; border-top: 1px solid var(--line); }
+  .scenario-grid { grid-template-columns: repeat(3, 1fr); }
 }
 
 @media (max-width: 680px) {
@@ -117,6 +144,14 @@ th { font-size: 13px; letter-spacing: .06em; text-transform: uppercase; }
   .archive-item .tag { display: none; }
   .article-shell { padding-top: 40px; }
   .article-body { font-size: 19px; }
+  .product-hero { padding-top: 52px; }
+  .demo-boundary, .goal-grid, .product-intro { display: block; }
+  .product-intro .section-label { margin-bottom: 10px; }
+  .scenario-grid { grid-template-columns: 1fr; }
+  .scenario-grid article { min-height: 0; }
+  .stress-strip { grid-template-columns: 1fr; }
+  .stress-strip p, .stress-strip p:first-child { padding: 16px 0; border: 0; border-top: 1px solid var(--line); }
+  .stress-strip p:first-child { border-top: 0; }
   .footer-wrap { align-items: flex-start; flex-direction: column; justify-content: center; gap: 4px; }
   .footer-wrap p { margin: 0; }
 }

--- a/tests/test_deafbench_product.py
+++ b/tests/test_deafbench_product.py
@@ -71,6 +71,16 @@ class DeafBenchProductPageTests(unittest.TestCase):
             "Whisper-AT medium.en 26.2% 67.7% 96.8% 7.34 4.46 GiB",
             self.visible_text,
         )
+        self.assertIn(
+            "Whisper-AT medium.en Recorded local observation "
+            "Synthetic-v2, real-speech smoke, and non-speech-v1",
+            self.visible_text,
+        )
+        self.assertIn(
+            "Distil-Whisper large-v3 Recorded local observation "
+            "Synthetic-v2 and real-speech smoke",
+            self.visible_text,
+        )
 
     def test_covers_accessibility_critical_entity_types(self) -> None:
         expected_entities = (

--- a/tests/test_deafbench_product.py
+++ b/tests/test_deafbench_product.py
@@ -53,6 +53,20 @@ class DeafBenchProductPageTests(unittest.TestCase):
             with self.subTest(model=model):
                 self.assertIn(model, self.visible_text)
 
+    def test_publishes_measured_whisper_evidence(self) -> None:
+        self.assertIn(
+            "These nine models ran the same 25-sample local corpus",
+            self.visible_text,
+        )
+        self.assertIn(
+            "Distil-Whisper large-v3 23.8% 66.1% 91.9% 0.80 CPU",
+            self.visible_text,
+        )
+        self.assertIn(
+            "Whisper-AT medium.en 26.2% 67.7% 96.8% 7.34 4.46 GiB",
+            self.visible_text,
+        )
+
     def test_covers_accessibility_critical_entity_types(self) -> None:
         expected_entities = (
             "Time",

--- a/tests/test_deafbench_product.py
+++ b/tests/test_deafbench_product.py
@@ -1,0 +1,80 @@
+from html.parser import HTMLParser
+from pathlib import Path
+import unittest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+PRODUCT_PAGE = ROOT / "products" / "deafbench" / "index.html"
+
+
+class ProductPageParser(HTMLParser):
+    def __init__(self) -> None:
+        super().__init__()
+        self.ids: set[str] = set()
+        self.text: list[str] = []
+
+    def handle_starttag(self, tag: str, attrs: list[tuple[str, str | None]]) -> None:
+        attributes = dict(attrs)
+        if attributes.get("id"):
+            self.ids.add(attributes["id"] or "")
+
+    def handle_data(self, data: str) -> None:
+        self.text.append(data)
+
+
+class DeafBenchProductPageTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.source = PRODUCT_PAGE.read_text(encoding="utf-8")
+        cls.parser = ProductPageParser()
+        cls.parser.feed(cls.source)
+        cls.visible_text = " ".join(" ".join(cls.parser.text).split())
+
+    def test_explains_public_demo_boundaries(self) -> None:
+        self.assertIn("Synthetic accessibility stress demo", self.visible_text)
+        self.assertIn("does not measure Deaf or hard-of-hearing speakers", self.visible_text)
+        self.assertIn("not a Hugging Face leaderboard result", self.visible_text)
+
+    def test_lists_every_integrated_model(self) -> None:
+        expected_models = (
+            "OpenAI Whisper turbo",
+            "Faster-Whisper small.en",
+            "Whisper-AT medium.en",
+            "Distil-Whisper large-v3",
+            "Qwen3-ASR 0.6B",
+            "Qwen3-ASR 1.7B",
+            "Parakeet TDT 0.6B v2",
+            "Granite Speech 4.1 2B",
+            "Granite Speech 4.1 2B NAR",
+            "ARK-ASR 0.6B",
+            "ARK-ASR 0.6B INT8 ONNX",
+        )
+        for model in expected_models:
+            with self.subTest(model=model):
+                self.assertIn(model, self.visible_text)
+
+    def test_covers_accessibility_critical_entity_types(self) -> None:
+        expected_entities = (
+            "Time",
+            "Date",
+            "Dosage",
+            "Name",
+            "Username",
+            "Code",
+            "Confirmation number",
+            "Wi-Fi name",
+            "Address",
+            "Money",
+            "Negation",
+        )
+        for entity in expected_entities:
+            with self.subTest(entity=entity):
+                self.assertIn(entity, self.visible_text)
+
+    def test_has_accessible_landmarks_and_unique_ids(self) -> None:
+        self.assertIn('<a class="skip-link" href="#main">', self.source)
+        self.assertIn('<main id="main"', self.source)
+        self.assertEqual(len(self.parser.ids), self.source.count(' id="'))
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_deafbench_product.py
+++ b/tests/test_deafbench_product.py
@@ -55,9 +55,11 @@ class DeafBenchProductPageTests(unittest.TestCase):
 
     def test_publishes_measured_whisper_evidence(self) -> None:
         self.assertIn(
-            "These nine models ran the same 25-sample local corpus",
+            "These nine rows are recorded local observations from the same 25-sample corpus",
             self.visible_text,
         )
+        self.assertIn("cannot be independently recomputed", self.visible_text)
+        self.assertIn("Recorded local observation", self.visible_text)
         self.assertIn(
             "Distil-Whisper large-v3 23.8% 66.1% 91.9% 0.80 CPU",
             self.visible_text,

--- a/tests/test_deafbench_product.py
+++ b/tests/test_deafbench_product.py
@@ -34,6 +34,9 @@ class DeafBenchProductPageTests(unittest.TestCase):
         self.assertIn("Synthetic accessibility stress demo", self.visible_text)
         self.assertIn("does not measure Deaf or hard-of-hearing speakers", self.visible_text)
         self.assertIn("not a Hugging Face leaderboard result", self.visible_text)
+        self.assertIn(
+            "I am not accepting customer audio or payment yet", self.visible_text
+        )
 
     def test_lists_every_integrated_model(self) -> None:
         expected_models = (

--- a/tests/test_deafbench_product.py
+++ b/tests/test_deafbench_product.py
@@ -76,5 +76,15 @@ class DeafBenchProductPageTests(unittest.TestCase):
         self.assertIn('<main id="main"', self.source)
         self.assertEqual(len(self.parser.ids), self.source.count(' id="'))
 
+    def test_homepage_and_sitemap_expose_product_page(self) -> None:
+        homepage = (ROOT / "index.html").read_text(encoding="utf-8")
+        sitemap = (ROOT / "sitemap.xml").read_text(encoding="utf-8")
+        self.assertIn('href="/products/deafbench/"', homepage)
+        self.assertIn(
+            "https://488315.github.io/products/deafbench/",
+            sitemap,
+        )
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

Add a dedicated DeafBench product demonstration to the existing GitHub Pages site. The page shows the synthetic stress scope, complete model inventory, comparable result lane, official-compatible goal, and current customer-run audit status without presenting unsupported claims.

## Problem

The portfolio currently exposes only a four-model snapshot. It does not show the expanded accessibility-critical scenarios, the complete eleven-model inventory, missing evidence, or the boundary between synthetic stress evidence and human disability or leaderboard evidence.

## Root cause

The existing home-page section predates the stress suite and complete model integration table.

## Solution

Add `/products/deafbench/` using the existing dependency-free site structure and visual language. Cover critical entity types, declared acoustic conditions, synthetic-v2 results, every integrated model path, and explicit non-claims; link the page from the home page and sitemap, with standard-library regression tests.

## Behavior changes

- Visitors can open a full DeafBench demonstration from the portfolio.
- The demonstration separates comparable results from historical or missing evidence.
- Synthetic stress results explicitly do not represent Deaf, hard-of-hearing, dysarthric, accent, age, or other demographic performance.
- The site states that customer audio and payment are not being accepted yet.

## Validation

- [x] `python -m unittest discover -s tests -v` — 5 passed
- [x] `python -m compileall -q tests`
- [x] `git diff main...HEAD --check`
- [ ] Browser screenshot comparison was not run because this change preserves the established static architecture and browser QA was not requested.

## Risk and rollback

The main risk is evidence text drifting from DeafBench. Tests fail if the complete inventory or claim boundaries disappear. Reverting the three commits removes the route, links, and test harness without affecting the rest of the site.

## Dependencies

The stress-suite and public development evidence are under review in DeafBench PRs #39 and #38. This page should not merge before those evidence changes.

## Review focus

Review the evidence boundaries, model inventory completeness, result-lane separation, mobile grid behavior, and direct first-person wording.

## Checklist

- [x] The PR contains one logical change.
- [x] The full diff has been self-reviewed.
- [x] Unrelated formatting and refactoring are excluded.
- [x] New behavior has automated tests where practical.
- [x] Existing tests were updated when behavior changed.
- [x] Failure paths and invalid input are handled.
- [x] Logs do not expose secrets or sensitive information.
- [x] Documentation was updated when contracts changed.
- [x] The branch is ready for review rather than exploratory work.
- [ ] All reviewer conversations are resolved.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a dedicated DeafBench product page with product details, model results, stress scenarios, evaluation goals, accessibility controls, and audit status.
  * Added responsive layouts for desktop, tablet, and mobile viewing.
  * Added benchmark demo links from relevant homepage sections.
  * Added the product page to the sitemap.

* **Accessibility**
  * Included accessible navigation, landmarks, controls, and page structure.

* **Documentation**
  * Clarified that sample-level artifacts are unpublished and results cannot be independently recomputed from the site or repository.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->