### PR TITLE
site: Link synthetic-v2 metadata

### DIFF
--- a/products/deafbench/index.html
+++ b/products/deafbench/index.html
@@ -92,6 +92,7 @@
       <div class="product-actions">
         <a class="button-link" href="https://github.com/488315/DeafBench">Read the code</a>
         <a class="text-link" href="https://pypi.org/project/deafbench/">Install from PyPI</a>
+        <a class="text-link" href="https://huggingface.co/datasets/kvjones0243/deafbench-synthetic-v2">View synthetic-v2 metadata</a>
         <a class="text-link" href="#demo">See the public demo ↓</a>
       </div>
     </header>

--- a/tests/test_deafbench_product.py
+++ b/tests/test_deafbench_product.py
@@ -150,6 +150,10 @@ class DeafBenchProductPageTests(unittest.TestCase):
     def test_links_to_installation_and_methodology(self) -> None:
         self.assertIn('href="https://pypi.org/project/deafbench/"', self.source)
         self.assertIn(
+            'href="https://huggingface.co/datasets/kvjones0243/deafbench-synthetic-v2"',
+            self.source,
+        )
+        self.assertIn(
             'href="https://github.com/488315/DeafBench/blob/main/docs/asr-evaluation-methodology.md"',
             self.source,
         )


### PR DESCRIPTION
## Summary

Add a direct product-page link to DeafBench's authorized Hugging Face synthetic-v2 metadata repository. Protect the discovery surface with the existing dependency-free site contract test.

## Problem

The public DeafBench page links the source repository, PyPI package, methodology, and demonstration, but it does not link the public Hugging Face dataset metadata required by the discovery roadmap.

## Root cause

The Hugging Face metadata repository was published after the original product-page link set was finalized.

## Solution

Add one accurately labeled link to the public synthetic-v2 metadata repository and assert its exact URL in the focused product-page test. No benchmark media, predictions, run artifacts, or publicity copy is added.

## Behavior changes

Visitors can navigate directly from the DeafBench product page to the synthetic-v2 metadata repository on Hugging Face.

## Validation

- [x] `python -m unittest discover -s tests -v` (9 passed)
- [x] `python -m compileall -q tests`
- [x] `git diff --check origin/main...HEAD`
- [x] Standards review (0 findings)
- [x] Specification review (0 findings)

## Risk and rollback

Risk is limited to one static external link. Revert commit `af73e93` if the public metadata location changes or becomes unavailable.

## Dependencies

The public dataset metadata at `kvjones0243/deafbench-synthetic-v2` must remain available.

## Review focus

Verify that the label describes metadata rather than audio and that the URL targets the authorized public repository.

## Checklist

- [x] The PR contains one logical change.
- [x] The full diff has been self-reviewed.
- [x] Unrelated formatting and refactoring are excluded.
- [x] New behavior has automated tests where practical.
- [x] Existing tests were updated when behavior changed.
- [x] Failure paths and invalid input are handled or not applicable.
- [x] Logs do not expose secrets or sensitive information.
- [x] Documentation was updated when contracts changed.
- [x] The branch is ready for review rather than exploratory work.
- [x] All reviewer conversations are resolved.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a product-action link to the DeafBench synthetic-v2 metadata dataset on Hugging Face.

* **Tests**
  * Updated link validation to ensure the new dataset link is available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->